### PR TITLE
fixed mobile view always shows OUT on load

### DIFF
--- a/mobile/mobile2.js
+++ b/mobile/mobile2.js
@@ -92,7 +92,7 @@ $(function(){
 				return;
 			}
 			
-			if(data.result.laststateIn === true) {
+			if(data.result.laststateIn == true) {
 				$('#change_button').attr({
 					'value':'out',
 					'class':'go'


### PR DESCRIPTION
Die mobile Ansicht ist kaputt, weil die json-rpc.php getLastDay laststateIn im json mit 0 oder 1 zurück gibt, das JS aber einen typsicheren Vergleich auf true macht.
